### PR TITLE
feat(im/convert): support content_v2 blocks in post message conversion

### DIFF
--- a/larksuite-oapi/src/main/java/com/lark/oapi/channel/normalize/converters/PostMessageConverter.java
+++ b/larksuite-oapi/src/main/java/com/lark/oapi/channel/normalize/converters/PostMessageConverter.java
@@ -14,8 +14,13 @@ import com.lark.oapi.channel.normalize.NormalizeTexts;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class PostMessageConverter implements ChannelMessageConverter {
+    private static final Pattern AT_MENTION_RE = Pattern.compile("<at(\\s+)user_id(\\s*)=(\\s*)\"(.*?)\">(.*?)</at>");
+    private static final Pattern IMAGE_KEY_RE = Pattern.compile("!\\[(.*?)\\]\\(([^)]+)\\)");
+
     @Override
     public ConvertResult convert(String rawContent, ConvertContext context) {
         JsonObject rawParsed = NormalizeJsons.parseObject(rawContent);
@@ -23,6 +28,22 @@ public class PostMessageConverter implements ChannelMessageConverter {
         if (body == null) {
             return new ConvertResult("[rich text message]", Collections.<ResourceDescriptor>emptyList());
         }
+
+        // Choose source paragraphs: prefer content_v2, fallback to content.
+        JsonArray sourceParagraphs = null;
+        if (body.has("content_v2") && body.get("content_v2").isJsonArray()) {
+            JsonArray cv2 = body.getAsJsonArray("content_v2");
+            if (cv2.size() > 0) {
+                sourceParagraphs = cv2;
+            }
+        }
+        if (sourceParagraphs == null && body.has("content") && body.get("content").isJsonArray()) {
+            sourceParagraphs = body.getAsJsonArray("content");
+        }
+        if (sourceParagraphs == null || sourceParagraphs.size() == 0) {
+            return new ConvertResult("[rich text message]", Collections.<ResourceDescriptor>emptyList());
+        }
+
         List<ResourceDescriptor> resources = new ArrayList<ResourceDescriptor>();
         List<String> lines = new ArrayList<String>();
         String title = NormalizeJsons.optString(body, "title");
@@ -30,30 +51,82 @@ public class PostMessageConverter implements ChannelMessageConverter {
             lines.add("**" + title + "**");
             lines.add("");
         }
-        JsonArray content = body.has("content") && body.get("content").isJsonArray() ? body.getAsJsonArray("content") : null;
-        if (content != null) {
-            for (int i = 0; i < content.size(); i++) {
-                JsonElement paragraphElement = content.get(i);
-                if (!paragraphElement.isJsonArray()) {
+
+        for (int i = 0; i < sourceParagraphs.size(); i++) {
+            JsonElement paragraphElement = sourceParagraphs.get(i);
+            if (!paragraphElement.isJsonArray()) {
+                continue;
+            }
+            JsonArray paragraph = paragraphElement.getAsJsonArray();
+            StringBuilder line = new StringBuilder();
+            for (int j = 0; j < paragraph.size(); j++) {
+                if (!paragraph.get(j).isJsonObject()) {
                     continue;
                 }
-                JsonArray paragraph = paragraphElement.getAsJsonArray();
-                StringBuilder line = new StringBuilder();
-                for (int j = 0; j < paragraph.size(); j++) {
-                    if (!paragraph.get(j).isJsonObject()) {
-                        continue;
-                    }
-                    line.append(renderElement(paragraph.get(j).getAsJsonObject(), context, resources));
-                }
-                lines.add(line.toString());
+                line.append(renderElement(paragraph.get(j).getAsJsonObject(), context, resources));
             }
+            lines.add(line.toString());
         }
+
         String contentText = NormalizeTexts.joinLines(lines).trim();
         return new ConvertResult(contentText.isEmpty() ? "[rich text message]" : contentText, resources);
     }
 
+    /**
+     * Post-process raw markdown text from an "md" element.
+     * Splits by fenced code block delimiters (```) and only applies
+     * transformations to text outside of properly paired code blocks.
+     * Unclosed fences are treated as outside-code-block text.
+     */
+    private String processMdText(String text, List<ResourceDescriptor> resources) {
+        String[] parts = text.split("```", -1);
+        int total = parts.length;
+        for (int i = 0; i < parts.length; i++) {
+            // Odd-index segments are inside code blocks, UNLESS it's the last
+            // segment of an even-length split (unclosed fence).
+            boolean isInside = (i % 2 == 1);
+            if (isInside && total % 2 == 0 && i == total - 1) {
+                isInside = false;
+            }
+            if (!isInside) {
+                // Outside code block: apply transformations.
+                Matcher atMatcher = AT_MENTION_RE.matcher(parts[i]);
+                StringBuffer sb = new StringBuffer();
+                while (atMatcher.find()) {
+                    String userId = atMatcher.group(4);
+                    String name = atMatcher.group(5);
+                    String replacement;
+                    if ("all".equals(userId) || "all_members".equals(userId)) {
+                        replacement = "@all";
+                    } else if (name != null && !name.isEmpty()) {
+                        replacement = "@" + name;
+                    } else {
+                        replacement = "@" + userId;
+                    }
+                    atMatcher.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+                }
+                atMatcher.appendTail(sb);
+                parts[i] = sb.toString();
+
+                // Extract image keys from ![...](key) patterns.
+                Matcher imgMatcher = IMAGE_KEY_RE.matcher(parts[i]);
+                while (imgMatcher.find()) {
+                    String key = imgMatcher.group(2);
+                    if (key != null && !key.isEmpty()) {
+                        resources.add(new ResourceDescriptor("image", key, null, null));
+                    }
+                }
+            }
+            // Inside code block: preserve as-is.
+        }
+        return String.join("```", parts);
+    }
+
     private String renderElement(JsonObject element, ConvertContext context, List<ResourceDescriptor> resources) {
         String tag = NormalizeJsons.optString(element, "tag");
+        if ("md".equals(tag)) {
+            return processMdText(NormalizeJsons.optString(element, "text", ""), resources);
+        }
         if ("text".equals(tag)) {
             JsonArray styles = element.has("style") && element.get("style").isJsonArray() ? element.getAsJsonArray("style") : null;
             return NormalizeTexts.applyStyle(NormalizeJsons.optString(element, "text", ""), styles);

--- a/larksuite-oapi/src/main/java/com/lark/oapi/channel/outbound/markdown/MarkdownPostConverter.java
+++ b/larksuite-oapi/src/main/java/com/lark/oapi/channel/outbound/markdown/MarkdownPostConverter.java
@@ -12,39 +12,8 @@ public final class MarkdownPostConverter {
 
     public static Map<String, Object> markdownToPost(String markdown, List<?> mentions) {
         List<List<Map<String, Object>>> paragraphs = new ArrayList<>();
-        String[] lines = (markdown == null ? "" : markdown.replace("\r\n", "\n")).split("\n", -1);
-        String fenceLang = null;
-        List<String> fenceBuffer = new ArrayList<>();
-        for (String line : lines) {
-            String trimmed = line.trim();
-            if (trimmed.matches("^```\\w*\\s*$")) {
-                if (fenceLang == null) {
-                    fenceLang = trimmed.length() > 3 ? trimmed.substring(3).trim() : "";
-                } else {
-                    paragraphs.add(Collections.singletonList(codeBlock(fenceLang, joinLines(fenceBuffer))));
-                    fenceLang = null;
-                    fenceBuffer.clear();
-                }
-                continue;
-            }
-            if (fenceLang != null) {
-                fenceBuffer.add(line);
-                continue;
-            }
-            if (trimmed.isEmpty()) {
-                paragraphs.add(Collections.singletonList(text("", null)));
-                continue;
-            }
-            if (trimmed.matches("^(-{3,}|_{3,}|\\*{3,})\\s*$")) {
-                paragraphs.add(Collections.singletonList(text("\u2014\u2014\u2014", null)));
-                continue;
-            }
-            paragraphs.add(parseInline(line));
-        }
-        if (fenceLang != null) {
-            paragraphs.add(Collections.singletonList(codeBlock(fenceLang, joinLines(fenceBuffer))));
-        }
 
+        // Prepend mentions as at elements for notification delivery.
         List<Map<String, Object>> mentionElements = ComposeMentions.composePostMentionElements(mentions);
         if (!mentionElements.isEmpty()) {
             List<Map<String, Object>> first = new ArrayList<>();
@@ -52,8 +21,14 @@ public final class MarkdownPostConverter {
                 first.add(mention);
                 first.add(text(" ", null));
             }
-            paragraphs.add(0, first);
+            paragraphs.add(first);
         }
+
+        // Wrap raw markdown in md tag.
+        Map<String, Object> mdElement = new LinkedHashMap<>();
+        mdElement.put("tag", "md");
+        mdElement.put("text", markdown == null ? "" : markdown);
+        paragraphs.add(Collections.singletonList(mdElement));
 
         Map<String, Object> locale = new LinkedHashMap<>();
         locale.put("title", "");
@@ -107,44 +82,15 @@ public final class MarkdownPostConverter {
                         line.append(text);
                     }
                     line.append("\n```");
+                } else if ("md".equals(tag)) {
+                    if (item.get("text") != null) {
+                        line.append(item.get("text"));
+                    }
                 }
             }
             lines.add(line.toString());
         }
         return joinLines(lines).trim();
-    }
-
-    private static List<Map<String, Object>> parseInline(String line) {
-        List<Map<String, Object>> output = new ArrayList<>();
-        java.util.regex.Matcher heading = java.util.regex.Pattern.compile("^(#{1,6})\\s+(.*)$").matcher(line);
-        if (heading.find()) {
-            output.add(text(heading.group(2), Collections.singletonList("bold")));
-            return output;
-        }
-        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile(
-                "(`[^`\\n]+`)|(\\[([^\\]]+)]\\(([^)]+)\\))|(\\*\\*[^*\\n]+\\*\\*)|(__[^_\\n]+__)|(\\*[^*\\n]+\\*)|(_[^_\\n]+_)");
-        java.util.regex.Matcher matcher = pattern.matcher(line);
-        int last = 0;
-        while (matcher.find()) {
-            if (matcher.start() > last) {
-                output.add(text(line.substring(last, matcher.start()), null));
-            }
-            String token = matcher.group();
-            if (token.startsWith("`")) {
-                output.add(text(token.substring(1, token.length() - 1), Collections.singletonList("code")));
-            } else if (token.startsWith("[")) {
-                output.add(link(matcher.group(3), matcher.group(4)));
-            } else if (token.startsWith("**") || token.startsWith("__")) {
-                output.add(text(token.substring(2, token.length() - 2), Collections.singletonList("bold")));
-            } else {
-                output.add(text(token.substring(1, token.length() - 1), Collections.singletonList("italic")));
-            }
-            last = matcher.end();
-        }
-        if (last < line.length()) {
-            output.add(text(line.substring(last), null));
-        }
-        return output.isEmpty() ? Collections.singletonList(text("", null)) : output;
     }
 
     private static Map<String, Object> text(String text, List<String> style) {
@@ -154,22 +100,6 @@ public final class MarkdownPostConverter {
         if (style != null && !style.isEmpty()) {
             element.put("style", style);
         }
-        return element;
-    }
-
-    private static Map<String, Object> codeBlock(String language, String code) {
-        Map<String, Object> element = new LinkedHashMap<>();
-        element.put("tag", "code_block");
-        element.put("language", language == null ? "" : language);
-        element.put("text", code == null ? "" : code);
-        return element;
-    }
-
-    private static Map<String, Object> link(String text, String href) {
-        Map<String, Object> element = new LinkedHashMap<>();
-        element.put("tag", "a");
-        element.put("text", text);
-        element.put("href", href);
         return element;
     }
 

--- a/larksuite-oapi/src/test/java/com/lark/oapi/channel/normalize/TestNormalizeConverters.java
+++ b/larksuite-oapi/src/test/java/com/lark/oapi/channel/normalize/TestNormalizeConverters.java
@@ -83,6 +83,22 @@ public class TestNormalizeConverters {
         assertResource(post.getResources().get(0), "image", "img_x", null, null, null);
     }
 
+    @Test
+    public void testPostConverterPrefersContentV2AndProcessesMdElements() {
+        ConvertResult post = convert("post",
+                "{\"zh_cn\":{\"title\":\"Title\","
+                        + "\"content\":[[{\"tag\":\"text\",\"text\":\"legacy content\"}]],"
+                        + "\"content_v2\":[[{\"tag\":\"md\",\"text\":\"hello <at user_id=\\\"all\\\">All</at> ![pic](img_md)\\n```java\\n<at user_id=\\\"ou_hidden\\\">Hidden</at> ![hidden](img_hidden)\\n```\"}]]}}",
+                null);
+
+        Assert.assertTrue(post.getContent().contains("**Title**"));
+        Assert.assertTrue(post.getContent().contains("hello @all ![pic](img_md)"));
+        Assert.assertTrue(post.getContent().contains("<at user_id=\"ou_hidden\">Hidden</at> ![hidden](img_hidden)"));
+        Assert.assertFalse(post.getContent().contains("legacy content"));
+        Assert.assertEquals(1, post.getResources().size());
+        assertResource(post.getResources().get(0), "image", "img_md", null, null, null);
+    }
+
     private ConvertResult convert(String messageType, String rawContent, MentionEvent[] mentions) {
         MentionState state = Mentions.extract(mentions, rawContent, botIdentity);
         return MessageConverters.convert(messageType, rawContent, state, options, "om_test");

--- a/larksuite-oapi/src/test/java/com/lark/oapi/channel/outbound/TestOutboundMarkdown.java
+++ b/larksuite-oapi/src/test/java/com/lark/oapi/channel/outbound/TestOutboundMarkdown.java
@@ -23,33 +23,33 @@ public class TestOutboundMarkdown {
 
     @Test
     public void testMarkdownToPostAndBackToPlainText() {
-        Map<String, Object> post = MarkdownPostConverter.markdownToPost("# Title\nsee [here](https://x.com)\n`code`",
-                Arrays.asList("ou_xxx"));
+        String markdown = "# Title\nsee [here](https://x.com)\n`code`";
+        Map<String, Object> post = MarkdownPostConverter.markdownToPost(markdown, Arrays.asList("ou_xxx"));
         String plain = MarkdownPostConverter.postToPlainText(post);
 
         Map<?, ?> zh = (Map<?, ?>) post.get("zh_cn");
-        List<?> firstParagraph = (List<?>) ((List<?>) zh.get("content")).get(0);
+        List<?> content = (List<?>) zh.get("content");
+        List<?> firstParagraph = (List<?>) content.get(0);
+        Map<?, ?> md = (Map<?, ?>) ((List<?>) content.get(1)).get(0);
         Assert.assertEquals("at", ((Map<?, ?>) firstParagraph.get(0)).get("tag"));
-        Assert.assertTrue(plain.contains("Title"));
-        Assert.assertTrue(plain.contains("here"));
-        Assert.assertTrue(plain.contains("code"));
+        Assert.assertEquals("md", md.get("tag"));
+        Assert.assertEquals(markdown, md.get("text"));
+        Assert.assertTrue(plain.contains("@ou_xxx"));
+        Assert.assertTrue(plain.contains(markdown));
     }
 
     @Test
-    public void testMarkdownCodeFenceToCodeBlock() {
+    public void testMarkdownCodeFenceIsPreservedAsRawMd() {
         String markdown = "before\n```java\npublic class Demo {\n    int value = 1;\n}\n```\nafter";
         Map<String, Object> post = MarkdownPostConverter.markdownToPost(markdown, null);
         String plain = MarkdownPostConverter.postToPlainText(post);
 
         Map<?, ?> zh = (Map<?, ?>) post.get("zh_cn");
         List<?> content = (List<?>) zh.get("content");
-        Map<?, ?> codeBlock = (Map<?, ?>) ((List<?>) content.get(1)).get(0);
-        Assert.assertEquals("code_block", codeBlock.get("tag"));
-        Assert.assertEquals("java", codeBlock.get("language"));
-        Assert.assertEquals("public class Demo {\n    int value = 1;\n}", codeBlock.get("text"));
-        Assert.assertTrue(plain.contains("```java"));
-        Assert.assertTrue(plain.contains("int value = 1;"));
-        Assert.assertTrue(plain.contains("```"));
+        Map<?, ?> md = (Map<?, ?>) ((List<?>) content.get(0)).get(0);
+        Assert.assertEquals("md", md.get("tag"));
+        Assert.assertEquals(markdown, md.get("text"));
+        Assert.assertEquals(markdown, plain);
     }
 
     @Test


### PR DESCRIPTION
## Summary
Support `content_v2` and `md` elements in post message conversion, improving Markdown, mention, and image resource compatibility across inbound and outbound flows.

## Changes
- Prefer `content_v2` when normalizing post messages, with fallback to legacy `content`.
- Add `md` element handling to render `<at ...>` mentions and extract Markdown image resources.
- Convert outbound Markdown posts using an `md` element to preserve raw Markdown content.
- Update unit tests for `content_v2`, `md` elements, code fence preservation, and resource extraction.

## Test Plan
- [ ] Unit tests pass: `mvn -pl larksuite-oapi -Dtest=TestNormalizeConverters,TestOutboundMarkdown test`
- [ ] Manually verify Markdown post send and parse flows work as expected