### PR TITLE
[codex] support register app addons options

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,41 @@ Real runnable demo:
 - [RegisterAppRealDemo](larksuite-oapi/src/test/java/com/lark/oapi/scene/registration/RegisterAppRealDemo.java)
 - [RegisterAppAppPresetE2E](sample/src/main/java/com/lark/oapi/sample/scene/registration/RegisterAppAppPresetE2E.java)
 
+### Custom scopes/events/callbacks and updating an existing app
+
+When creating an app, use `addons` to incrementally request scopes, event subscriptions and callbacks on top of the platform base template. They are pre-filled into the confirm page shown after the user opens the verification URL, and take effect after the user confirms:
+
+```java
+import com.lark.oapi.scene.registration.AppAddons;
+
+// Create: incrementally request scopes/events/callbacks, and only allow creating a new app.
+RegisterApp.register(RegisterAppOptions.newBuilder()
+        .addons(AppAddons.newBuilder()
+                .tenantScopes("im:message:send_as_bot")
+                .userScopes("calendar:calendar:read")
+                .tenantEvents("im.message.receive_v1")
+                .callbacks("card.action.trigger")
+                .build())
+        .createOnly(true)
+        .onQRCode(info -> System.out.println(info.getUrl()))
+        .build());
+
+// Update: pass the appId of an existing app to let the user confirm incremental config changes.
+RegisterApp.register(RegisterAppOptions.newBuilder()
+        .appId("cli_xxx")
+        .addons(AppAddons.newBuilder()
+                .tenantScopes("drive:drive.metadata:readonly")
+                .build())
+        .onQRCode(info -> System.out.println(info.getUrl()))
+        .build());
+```
+
+Notes:
+
+- `addons` is additive only. Items are merged on top of the base template; base permissions cannot be removed.
+- Only the 5 public config types are supported: tenant/user scopes, tenant/user events, and callbacks. Sensitive config such as event request URLs, `security.*`, and encrypt keys cannot travel through `addons`; use the [update application config OpenAPI](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/application-v7/application-v7/application-config/patch) instead.
+- The SDK validates the shape and non-empty values, not whether scope/event/callback names exist in the platform catalog.
+
 ### `RegisterAppOptions` parameters
 
 | Parameter | Description | Type | Required | Default |
@@ -98,6 +133,14 @@ Real runnable demo:
 | `appPreset.avatar` | App avatar URL candidates. Supports 1-6 URLs; the first one is selected by default. Page/server handles image rendering rules such as png/jpg/jpeg/webp/gif and GIF frame sampling. | `String` / `String[]` / `List<String>` | No | - |
 | `appPreset.name` | App name. Supports the `{user}` placeholder, replaced by the app creation page with the scanning user's name. | `String` | No | - |
 | `appPreset.desc` | App description. Supports the `{user}` placeholder. | `String` | No | - |
+| `addons` | Incremental scopes/events/callbacks pre-filled into the confirm page. | `AppAddons` | No | - |
+| `addons.scopes.tenant` | App-identity scopes, for example `im:message:send_as_bot`. | `String[]` / `List<String>` | No | - |
+| `addons.scopes.user` | User-identity scopes, for example `calendar:calendar:read`. | `String[]` / `List<String>` | No | - |
+| `addons.events.items.tenant` | App-identity events, for example `im.message.receive_v1`. | `String[]` / `List<String>` | No | - |
+| `addons.events.items.user` | User-identity events, for example `calendar.calendar.event.changed_v4`. | `String[]` / `List<String>` | No | - |
+| `addons.callbacks.items` | Callbacks, for example `card.action.trigger`. | `String[]` / `List<String>` | No | - |
+| `createOnly` | When `true`, the landing page only allows creating a new app and hides the select-existing-app entry. | `boolean` | No | `false` |
+| `appId` | App ID (`cli_` prefix) of an existing app. When set, the flow updates that app's config by asking the user to confirm the diff brought by `addons`. The page ignores it when `createOnly` is `true`. | `String` | No | - |
 | `onQRCode` | Callback when the verification URL is ready. Receives `QRCodeInfo` with `url` and `expireIn` | `Consumer<QRCodeInfo>` | Yes | - |
 | `onStatusChange` | Callback on polling status changes. Receives `StatusChangeInfo` | `Consumer<StatusChangeInfo>` | No | - |
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -153,6 +153,41 @@ public class Sample {
 - [RegisterAppRealDemo](larksuite-oapi/src/test/java/com/lark/oapi/scene/registration/RegisterAppRealDemo.java)
 - [RegisterAppAppPresetE2E](sample/src/main/java/com/lark/oapi/sample/scene/registration/RegisterAppAppPresetE2E.java)
 
+#### 自定义权限/事件/回调与更新已有应用
+
+创建应用时，可以通过 `addons` 在平台基础模板上增量申请权限、事件订阅和回调。这些配置会预填到用户打开验证链接后的确认页中，用户确认后生效：
+
+```java
+import com.lark.oapi.scene.registration.AppAddons;
+
+// 创建：增量申请权限/事件/回调，且只允许创建新应用。
+RegisterApp.register(RegisterAppOptions.newBuilder()
+        .addons(AppAddons.newBuilder()
+                .tenantScopes("im:message:send_as_bot")
+                .userScopes("calendar:calendar:read")
+                .tenantEvents("im.message.receive_v1")
+                .callbacks("card.action.trigger")
+                .build())
+        .createOnly(true)
+        .onQRCode(info -> System.out.println(info.getUrl()))
+        .build());
+
+// 更新：传入已有应用的 appId，让用户确认增量配置变更。
+RegisterApp.register(RegisterAppOptions.newBuilder()
+        .appId("cli_xxx")
+        .addons(AppAddons.newBuilder()
+                .tenantScopes("drive:drive.metadata:readonly")
+                .build())
+        .onQRCode(info -> System.out.println(info.getUrl()))
+        .build());
+```
+
+注意：
+
+- `addons` 仅支持增量叠加，不能删减基础模板里的权限。
+- 仅支持 5 类公开配置：应用/用户身份权限、应用/用户身份事件、回调。事件请求 URL、`security.*`、加密 key 等敏感配置不能通过 `addons` 传入，需要使用[更新应用开发配置 OpenAPI](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/application-v7/application-v7/application-config/patch)。
+- SDK 校验数据形状和非空值，不校验权限点/事件/回调名称是否存在于平台目录。
+
 #### `RegisterAppOptions` 参数
 
 | 参数 | 描述 | 类型 | 必须 | 默认 |
@@ -164,6 +199,14 @@ public class Sample {
 | `appPreset.avatar` | 应用头像候选 URL，支持 1-6 个；传多个时默认选中第一个。图片格式、GIF 截帧、裁切和展示由页面/服务端处理。 | `String` / `String[]` / `List<String>` | 否 | - |
 | `appPreset.name` | 应用名称，支持 `{user}` 占位符，由应用创建页替换为扫码用户名称。 | `String` | 否 | - |
 | `appPreset.desc` | 应用描述，支持 `{user}` 占位符。 | `String` | 否 | - |
+| `addons` | 增量权限/事件/回调配置，预填到确认页。 | `AppAddons` | 否 | - |
+| `addons.scopes.tenant` | 应用身份权限列表，例如 `im:message:send_as_bot`。 | `String[]` / `List<String>` | 否 | - |
+| `addons.scopes.user` | 用户身份权限列表，例如 `calendar:calendar:read`。 | `String[]` / `List<String>` | 否 | - |
+| `addons.events.items.tenant` | 应用身份事件列表，例如 `im.message.receive_v1`。 | `String[]` / `List<String>` | 否 | - |
+| `addons.events.items.user` | 用户身份事件列表，例如 `calendar.calendar.event.changed_v4`。 | `String[]` / `List<String>` | 否 | - |
+| `addons.callbacks.items` | 回调列表，例如 `card.action.trigger`。 | `String[]` / `List<String>` | 否 | - |
+| `createOnly` | 为 `true` 时落地页仅允许创建新应用，并隐藏选择已有应用入口。 | `boolean` | 否 | `false` |
+| `appId` | 已有应用的 App ID（`cli_` 前缀）。传入后流程会让用户确认 `addons` 带来的配置 diff。`createOnly` 为 `true` 时页面会忽略该参数。 | `String` | 否 | - |
 | `onQRCode` | 验证链接就绪时的回调，参数为 `QRCodeInfo`，包含 `url` 和 `expireIn` | `Consumer<QRCodeInfo>` | 是 | - |
 | `onStatusChange` | 轮询状态变化时的回调，参数为 `StatusChangeInfo` | `Consumer<StatusChangeInfo>` | 否 | - |
 

--- a/larksuite-oapi/src/main/java/com/lark/oapi/scene/registration/AppAddons.java
+++ b/larksuite-oapi/src/main/java/com/lark/oapi/scene/registration/AppAddons.java
@@ -1,0 +1,211 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Lark Technologies Pte. Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.lark.oapi.scene.registration;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Incremental app config pre-filled into the confirm page shown after the user
+ * scans the QR code.
+ *
+ * <p>The SDK only carries the five public config lists supported by the
+ * platform page: tenant and user scopes, tenant and user events, and callbacks.
+ * Sensitive manifest config such as event request URLs, security settings, and
+ * encrypt keys must be updated through the application config OpenAPI instead.</p>
+ */
+public class AppAddons {
+    private Scopes scopes;
+    private Events events;
+    private Callbacks callbacks;
+
+    private AppAddons() {
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public Scopes getScopes() {
+        return scopes;
+    }
+
+    public Events getEvents() {
+        return events;
+    }
+
+    public Callbacks getCallbacks() {
+        return callbacks;
+    }
+
+    public static class Scopes {
+        private List<String> tenant;
+        private List<String> user;
+
+        private Scopes() {
+        }
+
+        public List<String> getTenant() {
+            return unmodifiableOrNull(tenant);
+        }
+
+        public List<String> getUser() {
+            return unmodifiableOrNull(user);
+        }
+    }
+
+    public static class Events {
+        private EventItems items;
+
+        private Events() {
+        }
+
+        public EventItems getItems() {
+            return items;
+        }
+    }
+
+    public static class EventItems {
+        private List<String> tenant;
+        private List<String> user;
+
+        private EventItems() {
+        }
+
+        public List<String> getTenant() {
+            return unmodifiableOrNull(tenant);
+        }
+
+        public List<String> getUser() {
+            return unmodifiableOrNull(user);
+        }
+    }
+
+    public static class Callbacks {
+        private List<String> items;
+
+        private Callbacks() {
+        }
+
+        public List<String> getItems() {
+            return unmodifiableOrNull(items);
+        }
+    }
+
+    public static class Builder {
+        private final AppAddons addons = new AppAddons();
+
+        public Builder tenantScopes(String... scopes) {
+            return tenantScopes(toList(scopes));
+        }
+
+        public Builder tenantScopes(List<String> scopes) {
+            ensureScopes().tenant = copyOrNull(scopes);
+            return this;
+        }
+
+        public Builder userScopes(String... scopes) {
+            return userScopes(toList(scopes));
+        }
+
+        public Builder userScopes(List<String> scopes) {
+            ensureScopes().user = copyOrNull(scopes);
+            return this;
+        }
+
+        public Builder tenantEvents(String... events) {
+            return tenantEvents(toList(events));
+        }
+
+        public Builder tenantEvents(List<String> events) {
+            ensureEventItems().tenant = copyOrNull(events);
+            return this;
+        }
+
+        public Builder userEvents(String... events) {
+            return userEvents(toList(events));
+        }
+
+        public Builder userEvents(List<String> events) {
+            ensureEventItems().user = copyOrNull(events);
+            return this;
+        }
+
+        public Builder callbacks(String... callbacks) {
+            return callbacks(toList(callbacks));
+        }
+
+        public Builder callbacks(List<String> callbacks) {
+            ensureCallbacks().items = copyOrNull(callbacks);
+            return this;
+        }
+
+        public AppAddons build() {
+            return addons;
+        }
+
+        private Scopes ensureScopes() {
+            if (addons.scopes == null) {
+                addons.scopes = new Scopes();
+            }
+            return addons.scopes;
+        }
+
+        private EventItems ensureEventItems() {
+            if (addons.events == null) {
+                addons.events = new Events();
+            }
+            if (addons.events.items == null) {
+                addons.events.items = new EventItems();
+            }
+            return addons.events.items;
+        }
+
+        private Callbacks ensureCallbacks() {
+            if (addons.callbacks == null) {
+                addons.callbacks = new Callbacks();
+            }
+            return addons.callbacks;
+        }
+    }
+
+    private static List<String> toList(String... values) {
+        if (values == null) {
+            return null;
+        }
+        List<String> list = new ArrayList<>(values.length);
+        Collections.addAll(list, values);
+        return list;
+    }
+
+    private static List<String> copyOrNull(List<String> values) {
+        return values == null ? null : new ArrayList<>(values);
+    }
+
+    private static List<String> unmodifiableOrNull(List<String> values) {
+        return values == null ? null : Collections.unmodifiableList(values);
+    }
+}

--- a/larksuite-oapi/src/main/java/com/lark/oapi/scene/registration/AppAddonsEncoder.java
+++ b/larksuite-oapi/src/main/java/com/lark/oapi/scene/registration/AppAddonsEncoder.java
@@ -1,0 +1,105 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 Lark Technologies Pte. Ltd.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.lark.oapi.scene.registration;
+
+import com.lark.oapi.core.utils.Jsons;
+import com.lark.oapi.core.utils.Strings;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.zip.GZIPOutputStream;
+
+final class AppAddonsEncoder {
+    private static final String ERROR_INVALID_ARGUMENT = "invalid_argument";
+
+    private AppAddonsEncoder() {
+    }
+
+    static String encode(AppAddons addons) throws RegisterAppException {
+        int itemCount = validate(addons);
+        if (itemCount == 0) {
+            throw invalid("addons must contain at least one scope, event or callback");
+        }
+
+        String json = Jsons.DEFAULT.toJson(addons);
+        byte[] data = gzip(json.getBytes(StandardCharsets.UTF_8));
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(data);
+    }
+
+    private static int validate(AppAddons addons) throws RegisterAppException {
+        if (addons == null) {
+            return 0;
+        }
+
+        int itemCount = 0;
+        AppAddons.Scopes scopes = addons.getScopes();
+        if (scopes != null) {
+            itemCount += validateStringList(scopes.getTenant(), "addons.scopes.tenant");
+            itemCount += validateStringList(scopes.getUser(), "addons.scopes.user");
+        }
+
+        AppAddons.Events events = addons.getEvents();
+        if (events != null && events.getItems() != null) {
+            itemCount += validateStringList(events.getItems().getTenant(), "addons.events.items.tenant");
+            itemCount += validateStringList(events.getItems().getUser(), "addons.events.items.user");
+        }
+
+        AppAddons.Callbacks callbacks = addons.getCallbacks();
+        if (callbacks != null) {
+            itemCount += validateStringList(callbacks.getItems(), "addons.callbacks.items");
+        }
+
+        return itemCount;
+    }
+
+    private static int validateStringList(List<String> items, String path) throws RegisterAppException {
+        if (items == null) {
+            return 0;
+        }
+        for (int i = 0; i < items.size(); i++) {
+            if (Strings.isEmpty(items.get(i))) {
+                throw invalid(path + "[" + i + "] must be a non-empty string");
+            }
+        }
+        return items.size();
+    }
+
+    private static byte[] gzip(byte[] data) throws RegisterAppException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try (GZIPOutputStream gzipOutputStream = new GZIPOutputStream(outputStream)) {
+            gzipOutputStream.write(data);
+        } catch (IOException e) {
+            throw invalid("failed to encode addons");
+        }
+        return outputStream.toByteArray();
+    }
+
+    private static RegisterAppException invalid(String description) {
+        return new RegisterAppException(ERROR_INVALID_ARGUMENT, description);
+    }
+}

--- a/larksuite-oapi/src/main/java/com/lark/oapi/scene/registration/RegisterApp.java
+++ b/larksuite-oapi/src/main/java/com/lark/oapi/scene/registration/RegisterApp.java
@@ -51,6 +51,9 @@ public final class RegisterApp {
         if (opts.getOnQRCode() == null) {
             throw new RegisterAppException(ERROR_INVALID_ARGUMENT, "onQRCode is required");
         }
+        if (opts.getAppId() != null && Strings.isEmpty(opts.getAppId())) {
+            throw new RegisterAppException(ERROR_INVALID_ARGUMENT, "appId must be a non-empty string");
+        }
 
         String domain = Strings.isEmpty(opts.getDomain()) ? DEFAULT_FEISHU_DOMAIN : opts.getDomain();
         String larkDomain = Strings.isEmpty(opts.getLarkDomain()) ? DEFAULT_LARK_DOMAIN : opts.getLarkDomain();
@@ -67,7 +70,10 @@ public final class RegisterApp {
         String qrCodeUrl = buildQRCodeUrl(
                 beginResponse.verification_uri_complete,
                 opts.getSource(),
-                opts.getAppPreset()
+                opts.getAppPreset(),
+                opts.getAddons(),
+                opts.isCreateOnly(),
+                opts.getAppId()
         );
 
         opts.getOnQRCode().accept(new QRCodeInfo(qrCodeUrl, expireSeconds));
@@ -162,7 +168,12 @@ public final class RegisterApp {
                 .build();
     }
 
-    private static String buildQRCodeUrl(String verificationUriComplete, String source, AppPreset appPreset)
+    private static String buildQRCodeUrl(String verificationUriComplete,
+                                         String source,
+                                         AppPreset appPreset,
+                                         AppAddons addons,
+                                         boolean createOnly,
+                                         String appId)
             throws RegisterAppException {
         try {
             HttpUrl.Builder builder = HttpUrl.get(verificationUriComplete).newBuilder();
@@ -170,6 +181,13 @@ public final class RegisterApp {
             builder.setQueryParameter("source", Strings.isEmpty(source) ? SDK_NAME : SDK_NAME + "/" + source);
             builder.setQueryParameter("tp", "sdk");
             applyAppPreset(builder, appPreset);
+            applyAddons(builder, addons);
+            if (createOnly) {
+                builder.setQueryParameter("createOnly", "true");
+            }
+            if (Strings.isNotEmpty(appId)) {
+                builder.setQueryParameter("clientID", appId);
+            }
             return builder.build().toString();
         } catch (IllegalArgumentException e) {
             throw new RegisterAppException(ERROR_INVALID_RESPONSE, "invalid verification url");
@@ -208,6 +226,13 @@ public final class RegisterApp {
         if (appPreset.getDesc() != null) {
             builder.setQueryParameter("desc", appPreset.getDesc());
         }
+    }
+
+    private static void applyAddons(HttpUrl.Builder builder, AppAddons addons) throws RegisterAppException {
+        if (addons == null) {
+            return;
+        }
+        builder.setQueryParameter("addons", AppAddonsEncoder.encode(addons));
     }
 
     private static void notifyStatus(Consumer<StatusChangeInfo> callback, StatusChangeInfo info) {

--- a/larksuite-oapi/src/main/java/com/lark/oapi/scene/registration/RegisterAppOptions.java
+++ b/larksuite-oapi/src/main/java/com/lark/oapi/scene/registration/RegisterAppOptions.java
@@ -7,6 +7,9 @@ public class RegisterAppOptions {
     private String domain;
     private String larkDomain;
     private AppPreset appPreset;
+    private AppAddons addons;
+    private String appId;
+    private boolean createOnly;
     private Consumer<QRCodeInfo> onQRCode;
     private Consumer<StatusChangeInfo> onStatusChange;
 
@@ -31,6 +34,18 @@ public class RegisterAppOptions {
 
     public AppPreset getAppPreset() {
         return appPreset;
+    }
+
+    public AppAddons getAddons() {
+        return addons;
+    }
+
+    public String getAppId() {
+        return appId;
+    }
+
+    public boolean isCreateOnly() {
+        return createOnly;
     }
 
     public Consumer<QRCodeInfo> getOnQRCode() {
@@ -61,6 +76,21 @@ public class RegisterAppOptions {
 
         public Builder appPreset(AppPreset appPreset) {
             options.appPreset = appPreset;
+            return this;
+        }
+
+        public Builder addons(AppAddons addons) {
+            options.addons = addons;
+            return this;
+        }
+
+        public Builder appId(String appId) {
+            options.appId = appId;
+            return this;
+        }
+
+        public Builder createOnly(boolean createOnly) {
+            options.createOnly = createOnly;
             return this;
         }
 

--- a/larksuite-oapi/src/test/java/com/lark/oapi/scene/registration/TestRegisterApp.java
+++ b/larksuite-oapi/src/test/java/com/lark/oapi/scene/registration/TestRegisterApp.java
@@ -24,12 +24,15 @@
 
 package com.lark.oapi.scene.registration;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 import com.lark.oapi.okhttp.HttpUrl;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -39,12 +42,14 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.zip.GZIPInputStream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -54,6 +59,12 @@ import static org.junit.Assert.fail;
 public class TestRegisterApp {
 
     private static HttpUrl captureQRCodeUrl(AppPreset appPreset, String source) throws Exception {
+        return captureQRCodeUrl(RegisterAppOptions.newBuilder()
+                .source(source)
+                .appPreset(appPreset));
+    }
+
+    private static HttpUrl captureQRCodeUrl(RegisterAppOptions.Builder optionsBuilder) throws Exception {
         RegistrationTestServer server = new RegistrationTestServer();
         try {
             server.enqueueBegin(
@@ -69,10 +80,8 @@ public class TestRegisterApp {
             );
 
             List<QRCodeInfo> qrCodes = new ArrayList<>();
-            RegisterApp.register(RegisterAppOptions.newBuilder()
+            RegisterApp.register(optionsBuilder
                     .domain(server.baseUrl())
-                    .source(source)
-                    .appPreset(appPreset)
                     .onQRCode(qrCodes::add)
                     .build());
 
@@ -110,6 +119,69 @@ public class TestRegisterApp {
         }
     }
 
+    private static void assertInvalidOptions(RegisterAppOptions.Builder optionsBuilder, String expectedDescription)
+            throws Exception {
+        RegistrationTestServer server = new RegistrationTestServer();
+        try {
+            server.enqueueBegin(
+                    200,
+                    "{\"device_code\":\"dev_code\",\"verification_uri_complete\":\""
+                            + server.baseUrl()
+                            + "/verify\",\"interval\":1,\"expire_in\":600}"
+            );
+
+            try {
+                RegisterApp.register(optionsBuilder
+                        .domain(server.baseUrl())
+                        .onQRCode(info -> {
+                        })
+                        .build());
+                fail("Expected RegisterAppException");
+            } catch (RegisterAppException e) {
+                assertEquals("invalid_argument", e.getCode());
+                assertEquals(expectedDescription, e.getDescription());
+            }
+        } finally {
+            server.close();
+        }
+    }
+
+    private static void assertInvalidOptionsWithoutRequest(RegisterAppOptions.Builder optionsBuilder,
+                                                           String expectedDescription) throws Exception {
+        try {
+            RegisterApp.register(optionsBuilder
+                    .onQRCode(info -> {
+                    })
+                    .build());
+            fail("Expected RegisterAppException");
+        } catch (RegisterAppException e) {
+            assertEquals("invalid_argument", e.getCode());
+            assertEquals(expectedDescription, e.getDescription());
+        }
+    }
+
+    private static JsonElement decodeAddonsParam(HttpUrl url) throws IOException {
+        String encoded = url.queryParameter("addons");
+        assertNotNull(encoded);
+        int paddingLength = (4 - encoded.length() % 4) % 4;
+        String padded = encoded + "====".substring(0, paddingLength);
+        byte[] compressed = Base64.getUrlDecoder().decode(padded);
+
+        try (GZIPInputStream gzipInputStream = new GZIPInputStream(new ByteArrayInputStream(compressed));
+             ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[256];
+            int read;
+            while ((read = gzipInputStream.read(buffer)) != -1) {
+                outputStream.write(buffer, 0, read);
+            }
+            return JsonParser.parseString(outputStream.toString(StandardCharsets.UTF_8.name()));
+        }
+    }
+
+    private static JsonElement json(String value) {
+        return JsonParser.parseString(value);
+    }
+
     @Test
     public void testRegisterAppOmitsAppPresetWhenNotProvided() throws Exception {
         HttpUrl qrUrl = captureQRCodeUrl(null, null);
@@ -121,6 +193,9 @@ public class TestRegisterApp {
         assertTrue(qrUrl.queryParameterValues("avatar").isEmpty());
         assertEquals(null, qrUrl.queryParameter("name"));
         assertEquals(null, qrUrl.queryParameter("desc"));
+        assertEquals(null, qrUrl.queryParameter("addons"));
+        assertEquals(null, qrUrl.queryParameter("createOnly"));
+        assertEquals(null, qrUrl.queryParameter("clientID"));
     }
 
     @Test
@@ -263,6 +338,111 @@ public class TestRegisterApp {
                         .avatars(Arrays.asList("https://example.com/a.png", null))
                         .build(),
                 "appPreset.avatar[1] must be a non-empty string");
+    }
+
+    @Test
+    public void testRegisterAppEncodesAddonsIntoUrlSafeParam() throws Exception {
+        AppAddons addons = AppAddons.newBuilder()
+                .tenantScopes("im:message:send_as_bot")
+                .userScopes("calendar:calendar:read")
+                .tenantEvents("im.message.receive_v1")
+                .userEvents("calendar.calendar.event.changed_v4")
+                .callbacks("card.action.trigger")
+                .build();
+
+        HttpUrl qrUrl = captureQRCodeUrl(RegisterAppOptions.newBuilder()
+                .addons(addons));
+
+        assertTrue(qrUrl.queryParameter("addons").matches("^[A-Za-z0-9_-]+$"));
+        assertEquals(json("{"
+                        + "\"scopes\":{"
+                        + "\"tenant\":[\"im:message:send_as_bot\"],"
+                        + "\"user\":[\"calendar:calendar:read\"]"
+                        + "},"
+                        + "\"events\":{\"items\":{"
+                        + "\"tenant\":[\"im.message.receive_v1\"],"
+                        + "\"user\":[\"calendar.calendar.event.changed_v4\"]"
+                        + "}},"
+                        + "\"callbacks\":{\"items\":[\"card.action.trigger\"]}"
+                        + "}"),
+                decodeAddonsParam(qrUrl));
+    }
+
+    @Test
+    public void testRegisterAppAddonsCoexistsWithPresetAndCreateOnly() throws Exception {
+        HttpUrl qrUrl = captureQRCodeUrl(RegisterAppOptions.newBuilder()
+                .addons(AppAddons.newBuilder()
+                        .tenantScopes("im:message:send_as_bot")
+                        .build())
+                .appPreset(AppPreset.newBuilder()
+                        .name("MyApp")
+                        .build())
+                .createOnly(true));
+
+        assertEquals(json("{\"scopes\":{\"tenant\":[\"im:message:send_as_bot\"]}}"),
+                decodeAddonsParam(qrUrl));
+        assertEquals("MyApp", qrUrl.queryParameter("name"));
+        assertEquals("true", qrUrl.queryParameter("createOnly"));
+    }
+
+    @Test
+    public void testRegisterAppRejectsEmptyAddons() throws Exception {
+        assertInvalidOptions(RegisterAppOptions.newBuilder()
+                        .addons(AppAddons.newBuilder().build()),
+                "addons must contain at least one scope, event or callback");
+    }
+
+    @Test
+    public void testRegisterAppRejectsEmptyAddonsItemWithIndex() throws Exception {
+        assertInvalidOptions(RegisterAppOptions.newBuilder()
+                        .addons(AppAddons.newBuilder()
+                                .callbacks("card.action.trigger", "")
+                                .build()),
+                "addons.callbacks.items[1] must be a non-empty string");
+    }
+
+    @Test
+    public void testRegisterAppSetsClientIdFromAppId() throws Exception {
+        HttpUrl qrUrl = captureQRCodeUrl(RegisterAppOptions.newBuilder()
+                .appId("cli_a1b2c3"));
+
+        assertEquals("cli_a1b2c3", qrUrl.queryParameter("clientID"));
+    }
+
+    @Test
+    public void testRegisterAppCombinesAppIdWithAddons() throws Exception {
+        HttpUrl qrUrl = captureQRCodeUrl(RegisterAppOptions.newBuilder()
+                .appId("cli_a1b2c3")
+                .addons(AppAddons.newBuilder()
+                        .tenantScopes("drive:drive.metadata:readonly")
+                        .build()));
+
+        assertEquals("cli_a1b2c3", qrUrl.queryParameter("clientID"));
+        assertEquals(json("{\"scopes\":{\"tenant\":[\"drive:drive.metadata:readonly\"]}}"),
+                decodeAddonsParam(qrUrl));
+    }
+
+    @Test
+    public void testRegisterAppRejectsEmptyAppId() throws Exception {
+        assertInvalidOptionsWithoutRequest(RegisterAppOptions.newBuilder()
+                        .appId(""),
+                "appId must be a non-empty string");
+    }
+
+    @Test
+    public void testRegisterAppSetsCreateOnlyWhenEnabled() throws Exception {
+        HttpUrl qrUrl = captureQRCodeUrl(RegisterAppOptions.newBuilder()
+                .createOnly(true));
+
+        assertEquals("true", qrUrl.queryParameter("createOnly"));
+    }
+
+    @Test
+    public void testRegisterAppOmitsCreateOnlyWhenDisabled() throws Exception {
+        HttpUrl qrUrl = captureQRCodeUrl(RegisterAppOptions.newBuilder()
+                .createOnly(false));
+
+        assertEquals(null, qrUrl.queryParameter("createOnly"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add `AppAddons` and URL-safe gzip/base64 encoding for register-app incremental scopes, events, and callbacks.
- Add `RegisterAppOptions` support for `addons`, `createOnly`, and `appId`, mapping to the registration URL parameters used by the platform.
- Document the new register-app options in English and Chinese README sections.

## Test Plan
- `git diff --check`
- `mvn -DskipTests=false test`

## Notes
- Maven still reports an existing duplicate Gson dependency warning in `larksuite-oapi/pom.xml`; this PR does not change that dependency configuration.

Change-Id: Ic50d32beb30c200a701c0da501d5f45e2d6c6621