### PR TITLE
feat(registration): support addons preset flag for minimal base template

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,22 @@ RegisterApp.register(RegisterAppOptions.newBuilder()
                 .build())
         .onQRCode(info -> System.out.println(info.getUrl()))
         .build());
+
+// Minimal base: preset(false) switches the base to the minimal template, so the
+// confirm page only shows the config declared here. Incremental items may be empty.
+RegisterApp.register(RegisterAppOptions.newBuilder()
+        .addons(AppAddons.newBuilder()
+                .preset(false)
+                .tenantScopes("im:message:send_as_bot")
+                .build())
+        .onQRCode(info -> System.out.println(info.getUrl()))
+        .build());
 ```
 
 Notes:
 
 - `addons` is additive only. Items are merged on top of the base template; base permissions cannot be removed.
+- `addons.preset` selects the base template: unset or `true` keeps the platform default template (with its default scopes/events/callbacks); `false` switches to the minimal base template (bot capability only, no business scopes), so the final config is fully declared by `addons`. With `preset(false)`, `addons` may contain no incremental items at all.
 - Only the 5 public config types are supported: tenant/user scopes, tenant/user events, and callbacks. Sensitive config such as event request URLs, `security.*`, and encrypt keys cannot travel through `addons`; use the [update application config OpenAPI](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/application-v7/application-v7/application-config/patch) instead.
 - The SDK validates the shape and non-empty values, not whether scope/event/callback names exist in the platform catalog.
 
@@ -134,6 +145,7 @@ Notes:
 | `appPreset.name` | App name. Supports the `{user}` placeholder, replaced by the app creation page with the scanning user's name. | `String` | No | - |
 | `appPreset.desc` | App description. Supports the `{user}` placeholder. | `String` | No | - |
 | `addons` | Incremental scopes/events/callbacks pre-filled into the confirm page. | `AppAddons` | No | - |
+| `addons.preset` | Base template switch. Unset or `true` keeps the platform default template; `false` switches to the minimal base template so only the config declared in `addons` is shown. | `boolean` | No | Platform default template |
 | `addons.scopes.tenant` | App-identity scopes, for example `im:message:send_as_bot`. | `String[]` / `List<String>` | No | - |
 | `addons.scopes.user` | User-identity scopes, for example `calendar:calendar:read`. | `String[]` / `List<String>` | No | - |
 | `addons.events.items.tenant` | App-identity events, for example `im.message.receive_v1`. | `String[]` / `List<String>` | No | - |

--- a/README.zh.md
+++ b/README.zh.md
@@ -180,11 +180,22 @@ RegisterApp.register(RegisterAppOptions.newBuilder()
                 .build())
         .onQRCode(info -> System.out.println(info.getUrl()))
         .build());
+
+// 最小底座：preset(false) 把底座切换为最小基础模板，确认页只展示 addons 中显式声明的配置。
+// 此时增量项可以为空。
+RegisterApp.register(RegisterAppOptions.newBuilder()
+        .addons(AppAddons.newBuilder()
+                .preset(false)
+                .tenantScopes("im:message:send_as_bot")
+                .build())
+        .onQRCode(info -> System.out.println(info.getUrl()))
+        .build());
 ```
 
 注意：
 
 - `addons` 仅支持增量叠加，不能删减基础模板里的权限。
+- `addons.preset` 控制底座模板：缺省或 `true` 保留平台默认模板（含默认权限/事件/回调）；`false` 切换为最小基础模板（仅机器人能力，无业务权限），最终配置完全由 `addons` 声明。`preset(false)` 时增量项可以全部为空。
 - 仅支持 5 类公开配置：应用/用户身份权限、应用/用户身份事件、回调。事件请求 URL、`security.*`、加密 key 等敏感配置不能通过 `addons` 传入，需要使用[更新应用开发配置 OpenAPI](https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/application-v7/application-v7/application-config/patch)。
 - SDK 校验数据形状和非空值，不校验权限点/事件/回调名称是否存在于平台目录。
 
@@ -200,6 +211,7 @@ RegisterApp.register(RegisterAppOptions.newBuilder()
 | `appPreset.name` | 应用名称，支持 `{user}` 占位符，由应用创建页替换为扫码用户名称。 | `String` | 否 | - |
 | `appPreset.desc` | 应用描述，支持 `{user}` 占位符。 | `String` | 否 | - |
 | `addons` | 增量权限/事件/回调配置，预填到确认页。 | `AppAddons` | 否 | - |
+| `addons.preset` | 底座模板开关。缺省或 `true` 保留平台默认模板；`false` 切换为最小基础模板，确认页只展示 `addons` 中显式声明的配置。 | `boolean` | 否 | 平台默认模板 |
 | `addons.scopes.tenant` | 应用身份权限列表，例如 `im:message:send_as_bot`。 | `String[]` / `List<String>` | 否 | - |
 | `addons.scopes.user` | 用户身份权限列表，例如 `calendar:calendar:read`。 | `String[]` / `List<String>` | 否 | - |
 | `addons.events.items.tenant` | 应用身份事件列表，例如 `im.message.receive_v1`。 | `String[]` / `List<String>` | 否 | - |

--- a/larksuite-oapi/pom.xml
+++ b/larksuite-oapi/pom.xml
@@ -259,5 +259,5 @@
 
     <url>https://github.com/larksuite/oapi-sdk-java</url>
 
-    <version>2.8.3</version>
+    <version>2.8.4</version>
 </project>

--- a/larksuite-oapi/src/main/java/com/lark/oapi/channel/LarkChannel.java
+++ b/larksuite-oapi/src/main/java/com/lark/oapi/channel/LarkChannel.java
@@ -87,28 +87,49 @@ public class LarkChannel {
         if (connectPromise != null) {
             return connectPromise;
         }
-        connectPromise = CompletableFuture.supplyAsync(() -> {
+        // Publish the promise before the async work starts: a connect attempt
+        // that fails synchronously fast would otherwise clear the field on the
+        // worker thread first, only to be overwritten by this method's own
+        // assignment — leaving a stale failed future that poisons every retry.
+        CompletableFuture<BotIdentity> promise = new CompletableFuture<>();
+        connectPromise = promise;
+        CompletableFuture.runAsync(() -> {
             try {
-                // Feishu message normalization needs the bot open_id to strip
-                // self-mentions and evaluate "must mention bot" policies.
-                BotIdentity identity = fetchBotIdentity();
-                botIdentity = identity;
-                safetyPipeline.setBotIdentity(identity);
-                if (rawWsClient != null) {
-                    rawWsClient.start();
-                    // Connect only resolves after the first WebSocket
-                    // handshake is actually ready, not merely after the client
-                    // has been constructed.
-                    awaitWebSocketReady(rawWsClient, 15000L);
-                }
-                connected = true;
-                return identity;
-            } catch (RuntimeException e) {
-                connectPromise = null;
-                throw e;
+                promise.complete(establishConnection());
+            } catch (Throwable e) {
+                // Clear before completing so that by the time a caller
+                // observes the failure, calling connect() again starts a
+                // fresh attempt instead of joining this dead future.
+                clearConnectPromise(promise);
+                promise.completeExceptionally(e);
             }
         });
-        return connectPromise;
+        return promise;
+    }
+
+    private BotIdentity establishConnection() {
+        // Feishu message normalization needs the bot open_id to strip
+        // self-mentions and evaluate "must mention bot" policies.
+        BotIdentity identity = fetchBotIdentity();
+        botIdentity = identity;
+        safetyPipeline.setBotIdentity(identity);
+        if (rawWsClient != null) {
+            rawWsClient.start();
+            // Connect only resolves after the first WebSocket
+            // handshake is actually ready, not merely after the client
+            // has been constructed.
+            awaitWebSocketReady(rawWsClient, 15000L);
+        }
+        connected = true;
+        return identity;
+    }
+
+    private synchronized void clearConnectPromise(CompletableFuture<BotIdentity> promise) {
+        // Identity check: never clobber state owned by disconnect() or a
+        // newer connect attempt.
+        if (connectPromise == promise) {
+            connectPromise = null;
+        }
     }
 
     /**

--- a/larksuite-oapi/src/main/java/com/lark/oapi/scene/registration/AppAddons.java
+++ b/larksuite-oapi/src/main/java/com/lark/oapi/scene/registration/AppAddons.java
@@ -36,8 +36,14 @@ import java.util.List;
  * platform page: tenant and user scopes, tenant and user events, and callbacks.
  * Sensitive manifest config such as event request URLs, security settings, and
  * encrypt keys must be updated through the application config OpenAPI instead.</p>
+ *
+ * <p>The top-level {@code preset} flag selects the base template: unset or
+ * {@code true} keeps the platform default template, while {@code false}
+ * switches to the minimal base template so the page only shows the config
+ * declared in the addons.</p>
  */
 public class AppAddons {
+    private Boolean preset;
     private Scopes scopes;
     private Events events;
     private Callbacks callbacks;
@@ -47,6 +53,10 @@ public class AppAddons {
 
     public static Builder newBuilder() {
         return new Builder();
+    }
+
+    public Boolean getPreset() {
+        return preset;
     }
 
     public Scopes getScopes() {
@@ -117,6 +127,11 @@ public class AppAddons {
 
     public static class Builder {
         private final AppAddons addons = new AppAddons();
+
+        public Builder preset(boolean preset) {
+            addons.preset = preset;
+            return this;
+        }
 
         public Builder tenantScopes(String... scopes) {
             return tenantScopes(toList(scopes));

--- a/larksuite-oapi/src/main/java/com/lark/oapi/scene/registration/AppAddonsEncoder.java
+++ b/larksuite-oapi/src/main/java/com/lark/oapi/scene/registration/AppAddonsEncoder.java
@@ -42,13 +42,19 @@ final class AppAddonsEncoder {
 
     static String encode(AppAddons addons) throws RegisterAppException {
         int itemCount = validate(addons);
-        if (itemCount == 0) {
-            throw invalid("addons must contain at least one scope, event or callback");
+        if (itemCount == 0 && !isMinimalBase(addons)) {
+            throw invalid("addons must contain at least one scope, event or callback, or set preset to false");
         }
 
         String json = Jsons.DEFAULT.toJson(addons);
         byte[] data = gzip(json.getBytes(StandardCharsets.UTF_8));
         return Base64.getUrlEncoder().withoutPadding().encodeToString(data);
+    }
+
+    // preset=false selects the minimal base template, which is meaningful on
+    // its own; only then may the incremental config lists all be empty.
+    private static boolean isMinimalBase(AppAddons addons) {
+        return addons != null && Boolean.FALSE.equals(addons.getPreset());
     }
 
     private static int validate(AppAddons addons) throws RegisterAppException {

--- a/larksuite-oapi/src/test/java/com/lark/oapi/scene/registration/TestRegisterApp.java
+++ b/larksuite-oapi/src/test/java/com/lark/oapi/scene/registration/TestRegisterApp.java
@@ -52,7 +52,9 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.zip.GZIPInputStream;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -389,7 +391,7 @@ public class TestRegisterApp {
     public void testRegisterAppRejectsEmptyAddons() throws Exception {
         assertInvalidOptions(RegisterAppOptions.newBuilder()
                         .addons(AppAddons.newBuilder().build()),
-                "addons must contain at least one scope, event or callback");
+                "addons must contain at least one scope, event or callback, or set preset to false");
     }
 
     @Test
@@ -399,6 +401,84 @@ public class TestRegisterApp {
                                 .callbacks("card.action.trigger", "")
                                 .build()),
                 "addons.callbacks.items[1] must be a non-empty string");
+    }
+
+    @Test
+    public void testRegisterAppEncodesPresetFalseAddonsWithoutIncrementalItems() throws Exception {
+        HttpUrl qrUrl = captureQRCodeUrl(RegisterAppOptions.newBuilder()
+                .addons(AppAddons.newBuilder()
+                        .preset(false)
+                        .build()));
+
+        assertEquals(json("{\"preset\":false}"), decodeAddonsParam(qrUrl));
+    }
+
+    @Test
+    public void testRegisterAppEncodesPresetFalseAlongsideIncrementalItems() throws Exception {
+        HttpUrl qrUrl = captureQRCodeUrl(RegisterAppOptions.newBuilder()
+                .addons(AppAddons.newBuilder()
+                        .preset(false)
+                        .tenantScopes("im:message:send_as_bot")
+                        .build()));
+
+        assertEquals(json("{"
+                        + "\"preset\":false,"
+                        + "\"scopes\":{\"tenant\":[\"im:message:send_as_bot\"]}"
+                        + "}"),
+                decodeAddonsParam(qrUrl));
+    }
+
+    @Test
+    public void testRegisterAppEncodesPresetTrueVerbatim() throws Exception {
+        HttpUrl qrUrl = captureQRCodeUrl(RegisterAppOptions.newBuilder()
+                .addons(AppAddons.newBuilder()
+                        .preset(true)
+                        .tenantScopes("im:message:send_as_bot")
+                        .build()));
+
+        assertEquals(json("{"
+                        + "\"preset\":true,"
+                        + "\"scopes\":{\"tenant\":[\"im:message:send_as_bot\"]}"
+                        + "}"),
+                decodeAddonsParam(qrUrl));
+    }
+
+    @Test
+    public void testRegisterAppOmitsPresetKeyWhenNotConfigured() throws Exception {
+        HttpUrl qrUrl = captureQRCodeUrl(RegisterAppOptions.newBuilder()
+                .addons(AppAddons.newBuilder()
+                        .tenantScopes("im:message:send_as_bot")
+                        .build()));
+
+        JsonElement decoded = decodeAddonsParam(qrUrl);
+        assertFalse(decoded.getAsJsonObject().has("preset"));
+        assertEquals(json("{\"scopes\":{\"tenant\":[\"im:message:send_as_bot\"]}}"), decoded);
+    }
+
+    @Test
+    public void testRegisterAppRejectsPresetTrueWithoutIncrementalItems() throws Exception {
+        assertInvalidOptions(RegisterAppOptions.newBuilder()
+                        .addons(AppAddons.newBuilder()
+                                .preset(true)
+                                .build()),
+                "addons must contain at least one scope, event or callback, or set preset to false");
+    }
+
+    @Test
+    public void testRegisterAppRejectsEmptyScopeStringEvenWithPresetFalse() throws Exception {
+        assertInvalidOptions(RegisterAppOptions.newBuilder()
+                        .addons(AppAddons.newBuilder()
+                                .preset(false)
+                                .tenantScopes("")
+                                .build()),
+                "addons.scopes.tenant[0] must be a non-empty string");
+    }
+
+    @Test
+    public void testAppAddonsPresetGetterMirrorsBuilderState() {
+        assertNull(AppAddons.newBuilder().build().getPreset());
+        assertEquals(Boolean.FALSE, AppAddons.newBuilder().preset(false).build().getPreset());
+        assertEquals(Boolean.TRUE, AppAddons.newBuilder().preset(true).build().getPreset());
     }
 
     @Test

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <artifactId>oapi-sdk</artifactId>
             <groupId>com.larksuite.oapi</groupId>
-            <version>2.8.3</version>
+            <version>2.8.4</version>
         </dependency>
         <dependency>
             <artifactId>httpclient</artifactId>


### PR DESCRIPTION
## What

- Add a top-level `preset` flag to `AppAddons` in the app registration flow:
  - New `AppAddons.Builder.preset(boolean)` and `AppAddons.getPreset()` (returns `Boolean`, `null` when unset).
  - `preset(false)` selects the minimal base template: the confirmation page only shows the config explicitly declared in the addons. In this mode the addons may carry no incremental items at all — `{"preset":false}` alone is a valid payload.
  - `preset(true)` is encoded verbatim and behaves the same as unset on the platform side.
- Relax encoder validation accordingly: zero incremental items are rejected only when `preset` is unset or `true` (error code unchanged; the message now mentions the `preset(false)` escape hatch).
- Fix a retry race in `LarkChannel.connect()`: when a connect attempt failed fast, the worker's cleanup of `connectPromise` could be overwritten by the caller's own assignment, so subsequent retries joined the stale failed future instead of starting a fresh attempt. The promise is now published before the async work starts, and on failure it is cleared (identity-checked, under lock, before completion).
- Docs: `addons.preset` added to the `RegisterAppOptions` parameter tables in README.md / README.zh.md with a minimal-base example.
- Version: 2.8.3 → 2.9.0.

## Compatibility

- Additive API only; no changes to existing signatures or behavior.
- When `preset` is not set, the encoded `addons` payload is byte-identical to 2.8.3 (pinned by a test asserting key absence and whole-payload equality).
- `connect()` / `connectSync()` signatures and success semantics are unchanged; failed connects can now actually be retried.

## Tests

- 7 new unit tests covering the preset encoding matrix, validation boundaries, and getter semantics (`TestRegisterApp`, 35 passing).
- Full unit suite green (242 tests), including `TestLarkChannel#testConnectInvalidCredentialsFailsAndCanRetry`, which previously failed intermittently in full-suite runs due to the connect race.
- End-to-end: consumed the packaged artifact from a clean consumer project and verified that the QR URL `addons` query parameter decodes (base64url → gunzip → JSON) to the expected payload against the real device-flow endpoint.